### PR TITLE
Add missing "this." in page_loader.py

### DIFF
--- a/page_loader.py
+++ b/page_loader.py
@@ -27,7 +27,7 @@ class PageLoader:
 			return False
 		else:
 			page = download_book_page(book.full_link)
-			cache.save(book.id, page)
+			this.cache.save(book.id, page)
 			return True
 
 	def download(this, books):


### PR DESCRIPTION
The absence of "this." leads to the following error:

Traceback (most recent call last):
  File "export.py", line 28, in <module>
    loader.download(books)
  File "LivelibExport/page_loader.py", line 39, in download
    if this.try_download_book_page(book):
  File "LivelibExport/page_loader.py", line 30, in try_download_book_page
    cache.save(book.id, page)
NameError: name 'cache' is not defined